### PR TITLE
Bump databroker version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/databroker:v2.0.0b14 as base
+FROM ghcr.io/bluesky/databroker:v2.0.0b15 as base
 
 # git is used only for the pip install git+https:// below and can be
 # removed once that is no longer used.


### PR DESCRIPTION
Splitting the configuration across multiple files in https://github.com/NSLS2/tiled-site-config/pull/45 revealed some issues in tiled config parsing and the tiled container.

These were addressed in https://github.com/bluesky/tiled/pull/397 and https://github.com/bluesky/tiled/pull/398, and released in tiled `v0.1.0a84`. Databroker's `Dockerfile` was updated to base on that new release in https://github.com/bluesky/databroker/pull/753, and databroker was tagged as `v2.0.0b15` to produce a new tagged image.

This PR updates the NSLS2 distribution of Databroker to use that image.