### PR TITLE
`nsls2-detector-handlers` minimum version 0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 area-detector-handlers
 hdf5plugin  # The HDF5 LZ4 plugin is used by some Area Detectors. One example is the Eigers at CHX.
 ldap3
-nsls2-detector-handlers
+nsls2-detector-handlers>=0.1.0
 pillow
 pymongo


### PR DESCRIPTION
Uses https://github.com/NSLS-II/nsls2-detector-handlers/releases/tag/v0.1.0.