### PR TITLE
Bump databroker to v2.0.0b46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/databroker:v2.0.0b45 as base
+FROM ghcr.io/bluesky/databroker:v2.0.0b46 as base
 
 # git is used only for the pip install git+https:// below and can be
 # removed once that is no longer used.


### PR DESCRIPTION
Adds missing mongoquery dependency
to enable mixed queries that include ScanID.

See https://github.com/bluesky/databroker/pull/816/files