### PR TITLE
CI: harden GHA configuration

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
This adjusts the defaults per suggestions of zizmor to
reduce possible risks from giving GHA tasks more permissions
that required.
